### PR TITLE
Fix incorrect assertion in PipeBindingsTest.testInstantiateObject

### DIFF
--- a/src/test/java/org/apache/sling/pipes/PipeBindingsTest.java
+++ b/src/test/java/org/apache/sling/pipes/PipeBindingsTest.java
@@ -91,7 +91,7 @@ public class PipeBindingsTest extends AbstractPipeTest {
         assertNotNull("calendar should be instantiated", cal);
         assertEquals("year should be correct", 2012, cal.get(Calendar.YEAR));
         assertEquals("month should be correct", 4, cal.get(Calendar.MONTH));
-        assertEquals("date should be correct", 11, cal.get(Calendar.DAY_OF_MONTH));
+        assertEquals("date should be correct", 12, cal.get(Calendar.DAY_OF_MONTH));
     }
 
     @Test


### PR DESCRIPTION
Looks like a minor issue in the assertion.  

Binding was instantiated as `${new Date(2012,04,12)}`, but day of month was being compared to `11`.
